### PR TITLE
Create a dependabot.yml to update GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    timezone: America/New_York
+  open-pull-requests-limit: 10
+  reviewers:
+  - dconnolly
+  assignees:
+  - dconnolly


### PR DESCRIPTION
I'm pretty sure the actions workflow is out of date, which is why deployment failed.

For details, see: https://github.com/ZcashFoundation/coredns-zcash/actions/runs/1267893660


This is a copy of https://github.com/ZcashFoundation/zebra/blob/main/.github/dependabot.yml with the Cargo and label configs deleted.