### PR TITLE
Change dnsseeder and btcd versions for addrv2 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.17.3-alpine3.14 as builder
-LABEL maintainer "George Tankersley <george@zfnd.org>"
+LABEL maintainer "Zcash Foundation <engineers@zfnd.org>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.4-alpine as builder
+FROM golang:1.17.3-alpine3.14 as builder
 LABEL maintainer "George Tankersley <george@zfnd.org>"
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
@@ -11,13 +11,18 @@ RUN apk --no-cache add \
 	make
 
 ENV COREDNS_VERSION v1.6.9
+# TODO: change to "main" or tagged version
+ENV DNSSEEDER_VERSION addrv2
 
 RUN git clone --depth 1 --branch ${COREDNS_VERSION} https://github.com/coredns/coredns /go/src/github.com/coredns/coredns
 
 WORKDIR /go/src/github.com/coredns/coredns
 
 RUN echo "dnsseed:github.com/zcashfoundation/dnsseeder/dnsseed" >> /go/src/github.com/coredns/coredns/plugin.cfg
-RUN echo "replace github.com/btcsuite/btcd => github.com/gtank/btcd v0.0.0-20191012142736-b43c61a68604" >> /go/src/github.com/coredns/coredns/go.mod
+# Branch "addrv2". TODO: change to "main-zfnd" or tagged version
+RUN echo "replace github.com/btcsuite/btcd => github.com/ZcashFoundation/btcd v0.22.0-beta.0.20211116150640-079ebf598ccb" >> /go/src/github.com/coredns/coredns/go.mod
+
+RUN go get github.com/zcashfoundation/dnsseeder/dnsseed@${DNSSEEDER_VERSION}
 
 RUN make all \
 	&& mv coredns /usr/bin/coredns

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,15 @@ RUN apk --no-cache add \
 	make
 
 ENV COREDNS_VERSION v1.6.9
-# TODO: change to "main" or tagged version
-ENV DNSSEEDER_VERSION addrv2
+ENV DNSSEEDER_VERSION master
 
 RUN git clone --depth 1 --branch ${COREDNS_VERSION} https://github.com/coredns/coredns /go/src/github.com/coredns/coredns
 
 WORKDIR /go/src/github.com/coredns/coredns
 
 RUN echo "dnsseed:github.com/zcashfoundation/dnsseeder/dnsseed" >> /go/src/github.com/coredns/coredns/plugin.cfg
-# Branch "addrv2". TODO: change to "main-zfnd" or tagged version
-RUN echo "replace github.com/btcsuite/btcd => github.com/ZcashFoundation/btcd v0.22.0-beta.0.20211116150640-079ebf598ccb" >> /go/src/github.com/coredns/coredns/go.mod
+# Must be the same replace as in `dnsseeder`. Currently pointing to "main-zfnd" branch
+RUN echo "replace github.com/btcsuite/btcd => github.com/ZcashFoundation/btcd v0.22.0-beta.0.20211118133831-ca5d3008dd64" >> /go/src/github.com/coredns/coredns/go.mod
 
 RUN go get github.com/zcashfoundation/dnsseeder/dnsseed@${DNSSEEDER_VERSION}
 


### PR DESCRIPTION
See https://github.com/ZcashFoundation/btcd/pull/1 and https://github.com/ZcashFoundation/dnsseeder/pull/14

This a draft, after we merge those the versions can be updated and this can be moved from draft.

I also updated the Go version and added a env var to specify the `dnsseeder` version (something changed between Go 1.14 and and Go 1.17 and the `go get` is now required, which was convenient since it allows to easily specify the version)