### PR TITLE
Bump dnsseeder version for NU5 testnet reactivation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk --no-cache add \
 	make
 
 ENV COREDNS_VERSION v1.6.9
-ENV DNSSEEDER_VERSION master
+ENV DNSSEEDER_VERSION v0.2.1
 
 RUN git clone --depth 1 --branch ${COREDNS_VERSION} https://github.com/coredns/coredns /go/src/github.com/coredns/coredns
 


### PR DESCRIPTION
- We need a commit to master in order to trigger a deploy
- I figured it would also be best to point to a specific version of `dnsseeder` so I tagged it and pointed to it.

Closes https://github.com/ZcashFoundation/zebra/issues/3458