### PR TITLE
ci: pin actions to specific versions

### DIFF
--- a/.github/workflows/gcloud.yml
+++ b/.github/workflows/gcloud.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v3
 
     - name: Set project and image names
       run: |
@@ -27,7 +27,7 @@ jobs:
         echo "SHORT_SHA=$(git rev-parse --short=7 $GITHUB_SHA)" >> $GITHUB_ENV
 
     # Setup gcloud CLI
-    - uses: google-github-actions/setup-gcloud@master
+    - uses: google-github-actions/setup-gcloud@v0
       with:
         version: '295.0.0'
         project_id: ${{ env.PROJECT_ID }}


### PR DESCRIPTION
The google-github-actions/setup-gcloud action [does not support pinning to `master`](https://github.com/ZcashFoundation/coredns-zcash/runs/5761962010?check_suite_focus=true) so I changed it.

I also did the same for `actions/checkout` even if not needed.