### PR TITLE
Bump dnsseeder and btcd versions for minimum protocol version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk --no-cache add \
 	make
 
 ENV COREDNS_VERSION v1.6.9
-ENV DNSSEEDER_VERSION v0.2.1
+ENV DNSSEEDER_VERSION v0.2.2
 
 RUN git clone --depth 1 --branch ${COREDNS_VERSION} https://github.com/coredns/coredns /go/src/github.com/coredns/coredns
 
@@ -19,7 +19,7 @@ WORKDIR /go/src/github.com/coredns/coredns
 
 RUN echo "dnsseed:github.com/zcashfoundation/dnsseeder/dnsseed" >> /go/src/github.com/coredns/coredns/plugin.cfg
 # Must be the same replace as in `dnsseeder`. Currently pointing to "main-zfnd" branch
-RUN echo "replace github.com/btcsuite/btcd => github.com/ZcashFoundation/btcd v0.22.0-beta.0.20211118133831-ca5d3008dd64" >> /go/src/github.com/coredns/coredns/go.mod
+RUN echo "replace github.com/btcsuite/btcd => github.com/ZcashFoundation/btcd v0.22.0-beta.0.20220607000607-40dc9492aa42" >> /go/src/github.com/coredns/coredns/go.mod
 
 RUN go get github.com/zcashfoundation/dnsseeder/dnsseed@${DNSSEEDER_VERSION}
 

--- a/coredns/Corefile
+++ b/coredns/Corefile
@@ -10,7 +10,7 @@ mainnet.seeder.example.com {
 testnet.seeder.example.com {
     dnsseed {
         network testnet
-        bootstrap_peers testnet.z.cash:18233 testnet.is.yolo.money:18233 testnet.seeder.zfnd.org:18233
+        bootstrap_peers dnsseed.testnet.z.cash:18233 testnet.is.yolo.money:18233 testnet.seeder.zfnd.org:18233
         crawl_interval 15m
         record_ttl 300
     }


### PR DESCRIPTION
And other fixes

See https://github.com/ZcashFoundation/dnsseeder/releases/tag/v0.2.2