### PR TITLE
fix(corefile): use healthy peers for bootstrapping

### DIFF
--- a/coredns/Corefile
+++ b/coredns/Corefile
@@ -1,7 +1,7 @@
 mainnet.seeder.zfnd.org {
     dnsseed {
         network mainnet
-        bootstrap_peers mainnet.z.cash:8233 dnsseed.str4d.xyz:8233 mainnet.is.yolo.money:8233 mainnet.seeder.zfnd.org:8233
+        bootstrap_peers dnsseed.z.cash:8233 dnsseed.str4d.xyz:8233
         crawl_interval 30m
         record_ttl 600
     }
@@ -14,7 +14,7 @@ mainnet.seeder.zfnd.org {
 testnet.seeder.zfnd.org {
     dnsseed {
         network testnet
-        bootstrap_peers dnsseed.testnet.z.cash:18233 testnet.is.yolo.money:18233 testnet.seeder.zfnd.org:18233
+        bootstrap_peers dnsseed.testnet.z.cash:18233
         crawl_interval 15m
         record_ttl 300
     }


### PR DESCRIPTION
- Changed the addresses from `mainnet.z.cash` to `dnsseed.z.cash` as the latter has port `8233` open
- Changed the addresses from `testnet.z.cash` to `dnsseed.testnet.z.cash`
- Removed `mainnet.is.yolo.money:8233` as this peer is no longer working
- Removed `mainnet.seeder.zfnd.org:8233` and `testnet.seeder.zfnd.org:18233` as those are referencing itself, causing a crash loop when the seeder can't start