### PR TITLE
ci: remove models permission

### DIFF
--- a/.github/workflows/sub-build-docker-image.yml
+++ b/.github/workflows/sub-build-docker-image.yml
@@ -23,7 +23,20 @@ on:
         description: The image digest to be used on a caller workflow
         value: ${{ jobs.build.outputs.image_digest }}
 
-permissions: read-all
+permissions:
+  actions: read
+  attestations: read
+  checks: read
+  contents: read
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
 
 jobs:
   build:


### PR DESCRIPTION
`read-all` does not work anymore because it sets the `models` permission which does not work (I guess it's not enabled) - and we don't need since it's related to AI stuff